### PR TITLE
pausable component

### DIFF
--- a/src/pair/interface.cairo
+++ b/src/pair/interface.cairo
@@ -3,6 +3,13 @@ use starknet::ContractAddress;
 use openzeppelin::token::erc20::interface::{IERC20Dispatcher};
 
 #[starknet::interface]
+pub trait IPausable<TContractState> {
+    fn pause(ref self: TContractState);
+    fn unpause(ref self: TContractState);
+}
+
+
+#[starknet::interface]
 pub trait IPair<TContractState> {
     fn initialize(ref self: TContractState, token0: ContractAddress, token1: ContractAddress);
 


### PR DESCRIPTION
### Description
This PR adds a pause mechanism to the Pair contract, enabling the contract owner to temporarily halt swap operations in emergencies. This enhances the security and flexibility of the contract by allowing for quick intervention during critical situations.


### Key Features
1. Introduced functionality to pause and resume swap operations.
2. Only the contract owner can manage the pause state.
3. Swap operations are blocked when paused, while other functions remain unaffected.

### Impact
This update strengthens the contract’s ability to handle:

1. Security risks and vulnerabilities.
2. Unforeseen technical issues or irregular activities.
3. Compliance with external requirements.

### Compatibility
The changes are fully backward-compatible, ensuring seamless operation for existing users and transactions.